### PR TITLE
feat(renovate-presets): distinguish between github-actions preset for github-actions provider & github-actions users

### DIFF
--- a/github-actions-provider.json
+++ b/github-actions-provider.json
@@ -10,11 +10,7 @@
         "github-actions"
       ],
       "pinDigests": true,
-      "semanticCommitScope": "github-actions",
-      "semanticCommitType": "chore",
-      "schedule": [
-        "every 14 day"
-      ]
+      "semanticCommitScope": "github-actions"
     },
     {
       "automerge": true,
@@ -104,8 +100,7 @@
       "matchManagers": [
         "custom.regex"
       ],
-      "semanticCommitScope": "dev-tools",
-      "semanticCommitType": "chore"
+      "semanticCommitScope": "dev-tools"
     }
   ]
 }


### PR DESCRIPTION
- Repos that provide github-actions should use `github-actions-provider` preset.
  - This preset treats changes in versions of their dependencies (github-actions or dev-tools) as affecting the semver for conventional commits based version determination.
- Repos that primarily use other github-actions should use the existing `github-actions` preset.
  - This preset does not let changes in versions of their github-actions dependencies affect their own semver changes.
- Additionally drop the following from trusted github actions providing organizations:
- aquasecurity (given `trivy` got compromised)
  - fluxcd (we don't really use any of their github-actions anymore)